### PR TITLE
Fix sizing of text box in Firefox

### DIFF
--- a/dogbin/static/app.css
+++ b/dogbin/static/app.css
@@ -122,7 +122,8 @@ body {
     outline: none;
     resize: none;
     font-size: 1rem;
-    overflow-x: auto; }
+    overflow-x: auto;
+    height: calc(100% - 5.6rem); }
     #content textarea::placeholder {
       color: #ECEFF1; }
   #content pre#box {

--- a/dogbin/static/app.scss
+++ b/dogbin/static/app.scss
@@ -155,6 +155,7 @@ $linenos-width-plus: $linenos-width + .5rem;
         resize: none;
         font-size: $code-size;
         overflow-x: auto;
+        height: calc(100% - 5.6rem);
         &::placeholder {
             color: $text-light;
         }


### PR DESCRIPTION
The text box stays at a constant size that can fit about 3 lines in Firefox. It works fine in WebKit based browsers such as Chrome.

The issue was fixed by providing a height to make all browsers happy.